### PR TITLE
fix(formatEsi): align [X]/[/X] columns under all malformed inputs

### DIFF
--- a/src/lib/formatEsi.ts
+++ b/src/lib/formatEsi.ts
@@ -2,54 +2,200 @@ import { refactorWhitespace } from "./refactorWhitespace";
 
 const INDENT = "    ";
 
-// Lines that ARE just an opening tag, e.g. "[STEP 10]" or "[STEP INPUTS]".
-// Mid-line tags (e.g. `Step Conditions = <pre>` or `foo [BAR]`) are treated
-// as regular content so their depth isn't disturbed. A trailing "# comment"
-// after the tag (with any amount of whitespace before the #) is allowed —
-// e.g. `[429_FOO_input1]          # Scenario 1`.
-const OPENING_TAG_LINE = /^\[[^/\]][^\]]*\]\s*(?:#.*)?$/;
-const CLOSING_TAG_LINE = /^\[\/[^\]]+\]\s*(?:#.*)?$/;
+// Whole-line opening tag, e.g. "[STEP 10]" or "[STEP INPUTS]". A trailing
+// "# comment" after the tag is allowed — e.g. "[429_FOO_input1]  # Scenario 1".
+// Mid-line tags (e.g. `foo = [bar]`) are treated as content. Capture group
+// extracts the tag name so it can be matched against its closer.
+const OPENING_TAG_NAME = /^\[([^/\]][^\]]*)\]\s*(?:#.*)?$/;
 
-// `<pre>...</pre>` blocks (used by Step Conditions / Step Expected Results)
-// participate in depth tracking just like [TAG]/[/TAG]:
-//   - A line ending with `<pre>` (and not also closing it on the same line)
-//     opens a block — content on subsequent lines indents one level deeper.
-//   - A line that IS just `</pre>` closes the block.
-// This produces clean output where `<br/>` lines sit one indent past the
-// `Step Conditions = <pre>` line and `</pre>` aligns back with it, instead
-// of preserving whatever (often misaligned) column the source happened to
-// use.
-const PRE_OPENER_AT_END = /<pre[^>]*>\s*$/i;
-const PRE_CLOSER_WHOLE_LINE = /^<\/pre>\s*$/i;
+// Whole-line closing tag. The name capture lets us match it against the
+// open tag on the top of the stack — strict-name matching prevents an
+// orphaned [/X] from silently popping an unrelated [Y].
+const CLOSING_TAG_LINE = /^\[\/([^\]]+)\]\s*(?:#.*)?$/;
+
+// `<pre>...</pre>` blocks participate in depth tracking like [TAG]/[/TAG]:
+//   - A line ending with `<pre>` opens a block (with optional `# comment`).
+//   - A line ending with `</pre>` closes it (also optional `# comment`).
+// The CLOSER is intentionally `$`-anchored only (not `^`-anchored) so a
+// stray `content </pre>` on one line still terminates the block.
+// `\b` on the opener prevents matching e.g. `<prefix>`.
+const PRE_OPENER_AT_END = /<pre\b[^>]*>\s*(?:#.*)?$/i;
+const PRE_CLOSER_AT_END = /<\/pre>\s*(?:#.*)?$/i;
+
+type Context =
+  | { kind: "tag"; name: string }
+  | { kind: "pre" };
+
+type TagPending = { idx: number; name: string };
+
+// Pre-scan to identify opens that will never get a matching close. These
+// "orphan" opens are recorded by line index; the main pass renders them at
+// the current depth but does NOT push them onto the stack, so a stray
+// `[NeverClosed]` or unclosed `<pre>` early in a file does not cascade-shift
+// every subsequent tag's indent.
+//
+// Two phases:
+//   1. Match <pre>/</pre> pairs. Unmatched <pre> openers are orphans;
+//      matched pairs produce an opener→closer index map.
+//   2. Match [TAG]/[/TAG] by name, *skipping over matched pre regions*
+//      entirely (their content is opaque for tag purposes). Mismatched
+//      closes are left for the main pass to treat as content. Opens
+//      bypassed by a deeper [/X] match (e.g. `[B]` inside `[A]...[/A]`
+//      with no `[/B]`) are also orphans.
+function findOrphanLineIndices(lines: string[]): Set<number> {
+  const orphan = new Set<number>();
+
+  // Phase 1: pre matching.
+  const preOpenToClose = new Map<number, number>();
+  const preStack: number[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const s = lines[i].trim();
+    if (s === "") continue;
+    const isOpener = PRE_OPENER_AT_END.test(s);
+    const isCloser = PRE_CLOSER_AT_END.test(s);
+    if (isOpener && isCloser) continue;
+    if (isOpener) {
+      preStack.push(i);
+      continue;
+    }
+    if (isCloser) {
+      const openerIdx = preStack.pop();
+      if (openerIdx !== undefined) {
+        preOpenToClose.set(openerIdx, i);
+      }
+    }
+  }
+  for (const idx of preStack) {
+    orphan.add(idx);
+  }
+
+  // Phase 2: tag matching, skipping matched pre regions.
+  const pending: TagPending[] = [];
+  let i = 0;
+  while (i < lines.length) {
+    const s = lines[i].trim();
+    if (s === "") {
+      i += 1;
+      continue;
+    }
+    const preCloseAt = preOpenToClose.get(i);
+    if (preCloseAt !== undefined) {
+      i = preCloseAt + 1;
+      continue;
+    }
+    if (orphan.has(i)) {
+      // unmatched <pre> opener — treat as content for tag purposes
+      i += 1;
+      continue;
+    }
+    const closeMatch = s.match(CLOSING_TAG_LINE);
+    if (closeMatch) {
+      const name = closeMatch[1].trim();
+      let foundAt = -1;
+      for (let j = pending.length - 1; j >= 0; j--) {
+        if (pending[j].name === name) {
+          foundAt = j;
+          break;
+        }
+      }
+      if (foundAt !== -1) {
+        for (let j = foundAt + 1; j < pending.length; j++) {
+          orphan.add(pending[j].idx);
+        }
+        pending.length = foundAt;
+      }
+      i += 1;
+      continue;
+    }
+    const openMatch = s.match(OPENING_TAG_NAME);
+    if (openMatch) {
+      pending.push({ idx: i, name: openMatch[1].trim() });
+    }
+    i += 1;
+  }
+  for (const p of pending) {
+    orphan.add(p.idx);
+  }
+  return orphan;
+}
 
 export function formatEsi(text: string): string {
   const normalized = refactorWhitespace(text);
   const lines = normalized.split(/\r?\n/);
+  const orphan = findOrphanLineIndices(lines);
   const out: string[] = [];
-  let depth = 0;
+  const stack: Context[] = [];
 
-  for (const line of lines) {
-    const stripped = line.trim();
+  const inPre = (): boolean =>
+    stack.length > 0 && stack[stack.length - 1].kind === "pre";
+
+  for (let i = 0; i < lines.length; i++) {
+    const stripped = lines[i].trim();
 
     if (stripped === "") {
       out.push("");
       continue;
     }
 
-    const tagClosing = CLOSING_TAG_LINE.test(stripped);
-    const tagOpening = !tagClosing && OPENING_TAG_LINE.test(stripped);
-    const preCloser = PRE_CLOSER_WHOLE_LINE.test(stripped);
-    const preOpener = !preCloser && PRE_OPENER_AT_END.test(stripped);
-
-    if (tagClosing || preCloser) {
-      depth = Math.max(0, depth - 1);
+    // Inside a <pre> block, every line is raw content. Only </pre> exits
+    // the block — bracket-tag-looking content (`[STEP X]`, `[/Y]`, etc.)
+    // does NOT affect depth here.
+    if (inPre()) {
+      if (PRE_CLOSER_AT_END.test(stripped)) {
+        stack.pop();
+        out.push(INDENT.repeat(stack.length) + stripped);
+      } else {
+        out.push(INDENT.repeat(stack.length) + stripped);
+      }
+      continue;
     }
 
-    out.push(INDENT.repeat(depth) + stripped);
+    const isPreOpener = PRE_OPENER_AT_END.test(stripped);
+    const isPreCloser = PRE_CLOSER_AT_END.test(stripped);
 
-    if (tagOpening || preOpener) {
-      depth += 1;
+    if (isPreOpener && isPreCloser) {
+      out.push(INDENT.repeat(stack.length) + stripped);
+      continue;
     }
+
+    if (isPreCloser) {
+      // Orphan </pre> with no open pre on the stack — treat as content.
+      out.push(INDENT.repeat(stack.length) + stripped);
+      continue;
+    }
+
+    if (isPreOpener) {
+      out.push(INDENT.repeat(stack.length) + stripped);
+      if (!orphan.has(i)) {
+        stack.push({ kind: "pre" });
+      }
+      continue;
+    }
+
+    const closeMatch = stripped.match(CLOSING_TAG_LINE);
+    if (closeMatch) {
+      const name = closeMatch[1].trim();
+      const top = stack[stack.length - 1];
+      if (top && top.kind === "tag" && top.name === name) {
+        stack.pop();
+        out.push(INDENT.repeat(stack.length) + stripped);
+      } else {
+        // Mismatched or orphan close — render at current depth, no pop.
+        out.push(INDENT.repeat(stack.length) + stripped);
+      }
+      continue;
+    }
+
+    const openMatch = stripped.match(OPENING_TAG_NAME);
+    if (openMatch) {
+      out.push(INDENT.repeat(stack.length) + stripped);
+      if (!orphan.has(i)) {
+        stack.push({ kind: "tag", name: openMatch[1].trim() });
+      }
+      continue;
+    }
+
+    out.push(INDENT.repeat(stack.length) + stripped);
   }
 
   return out.join("\n");

--- a/src/test/unit/formatEsi.test.ts
+++ b/src/test/unit/formatEsi.test.ts
@@ -174,4 +174,210 @@ describe("formatEsi", () => {
     const expected = "[A]\n    foo\n[/A]   # done";
     assert.strictEqual(formatEsi(input), expected);
   });
+
+  it("recognizes </pre> with a trailing # comment as a pre closer", () => {
+    const input = [
+      "[A]",
+      "cond = <pre>",
+      "content",
+      "</pre>   # end of pre",
+      "[/A]",
+    ].join("\n");
+    const expected = [
+      "[A]",
+      "    cond = <pre>",
+      "        content",
+      "    </pre>   # end of pre",
+      "[/A]",
+    ].join("\n");
+    assert.strictEqual(formatEsi(input), expected);
+  });
+
+  it("recognizes <pre> with a trailing # comment as a pre opener", () => {
+    const input = [
+      "[A]",
+      "cond = <pre> # opener",
+      "content",
+      "</pre>",
+      "[/A]",
+    ].join("\n");
+    const expected = [
+      "[A]",
+      "    cond = <pre> # opener",
+      "        content",
+      "    </pre>",
+      "[/A]",
+    ].join("\n");
+    assert.strictEqual(formatEsi(input), expected);
+  });
+
+  it("treats bracket-tag-like lines inside a <pre> block as raw content", () => {
+    const input = [
+      "[A]",
+      "cond = <pre>",
+      "[STEP X]",
+      "some content",
+      "</pre>",
+      "[/A]",
+    ].join("\n");
+    const expected = [
+      "[A]",
+      "    cond = <pre>",
+      "        [STEP X]",
+      "        some content",
+      "    </pre>",
+      "[/A]",
+    ].join("\n");
+    assert.strictEqual(formatEsi(input), expected);
+  });
+
+  it("closes a <pre> when </pre> is preceded by content on the same line", () => {
+    const input = [
+      "[A]",
+      "cond = <pre>",
+      "foo",
+      "content here </pre>",
+      "[/A]",
+    ].join("\n");
+    const expected = [
+      "[A]",
+      "    cond = <pre>",
+      "        foo",
+      "    content here </pre>",
+      "[/A]",
+    ].join("\n");
+    assert.strictEqual(formatEsi(input), expected);
+  });
+
+  it("does not let an orphaned opening tag shift subsequent closers", () => {
+    const input = [
+      "[A]",
+      "foo",
+      "[StrayTag]",
+      "bar",
+      "[/A]",
+    ].join("\n");
+    const expected = [
+      "[A]",
+      "    foo",
+      "    [StrayTag]",
+      "    bar",
+      "[/A]",
+    ].join("\n");
+    assert.strictEqual(formatEsi(input), expected);
+  });
+
+  it("does not let an orphaned <pre> shift subsequent closers", () => {
+    const input = [
+      "[A]",
+      "cond = <pre>",
+      "content1",
+      "content2",
+      "[/A]",
+    ].join("\n");
+    const expected = [
+      "[A]",
+      "    cond = <pre>",
+      "    content1",
+      "    content2",
+      "[/A]",
+    ].join("\n");
+    assert.strictEqual(formatEsi(input), expected);
+  });
+
+  it("treats a mismatched closing tag as content (no pop)", () => {
+    const input = [
+      "[A]",
+      "[B]",
+      "foo",
+      "[/C]",
+      "bar",
+      "[/B]",
+      "[/A]",
+    ].join("\n");
+    const expected = [
+      "[A]",
+      "    [B]",
+      "        foo",
+      "        [/C]",
+      "        bar",
+      "    [/B]",
+      "[/A]",
+    ].join("\n");
+    assert.strictEqual(formatEsi(input), expected);
+  });
+
+  it("handles uppercase <PRE>/</PRE> the same as lowercase", () => {
+    const input = [
+      "[A]",
+      "cond = <PRE>",
+      "foo",
+      "</PRE>",
+      "[/A]",
+    ].join("\n");
+    const expected = [
+      "[A]",
+      "    cond = <PRE>",
+      "        foo",
+      "    </PRE>",
+      "[/A]",
+    ].join("\n");
+    assert.strictEqual(formatEsi(input), expected);
+  });
+
+  it("recognizes <pre> with attributes as a pre opener", () => {
+    const input = [
+      "[A]",
+      "cond = <pre class=\"x\">",
+      "foo",
+      "</pre>",
+      "[/A]",
+    ].join("\n");
+    const expected = [
+      "[A]",
+      "    cond = <pre class=\"x\">",
+      "        foo",
+      "    </pre>",
+      "[/A]",
+    ].join("\n");
+    assert.strictEqual(formatEsi(input), expected);
+  });
+
+  it("treats an orphan </pre> with no open <pre> as content", () => {
+    const input = [
+      "[A]",
+      "foo",
+      "</pre>",
+      "bar",
+      "[/A]",
+    ].join("\n");
+    const expected = [
+      "[A]",
+      "    foo",
+      "    </pre>",
+      "    bar",
+      "[/A]",
+    ].join("\n");
+    assert.strictEqual(formatEsi(input), expected);
+  });
+
+  it("produces identical output for CRLF and LF input", () => {
+    const lf = "[A]\nfoo\n[B]\nbar\n[/B]\n[/A]";
+    const crlf = "[A]\r\nfoo\r\n[B]\r\nbar\r\n[/B]\r\n[/A]";
+    assert.strictEqual(formatEsi(crlf), formatEsi(lf));
+  });
+
+  it("is idempotent on Bug 3 fixture (bracket-like content inside <pre>)", () => {
+    const input = [
+      "[A]",
+      "cond = <pre>",
+      "[STEP X]",
+      "some content",
+      "</pre>",
+      "[/A]",
+    ].join("\n");
+    const once = formatEsi(input);
+    const twice = formatEsi(once);
+    assert.strictEqual(twice, once);
+  });
 });


### PR DESCRIPTION
The depth-counter formatter produced misaligned [X]/[/X] pairs whenever the input had any of:

  - </pre> with a trailing # comment (closer regex didn't allow it)
  - <pre> with a trailing # comment (opener regex didn't allow it)
  - bracket-tag-looking content inside a <pre> block (parsed as a real tag — the most common real-world trigger)
  - text before </pre> on the same line (closer required ^</pre>)
  - orphan opening tag never closed (depth stayed elevated forever)
  - orphan <pre> never closed (same)

A single early defect cascaded: every closing tag after it landed one indent too deep. Once a user saw "every tag is misaligned" the file was effectively un-formattable.

Replace the integer depth counter with a Context[] stack plus a two-phase orphan pre-scan:

  Phase 1: match <pre>/</pre> pairs and record opener-to-closer indices.
           Unmatched <pre> openers are orphans.
  Phase 2: match [TAG]/[/TAG] by name, skipping over matched pre
           regions entirely. Opens bypassed by a deeper [/X] match
           (e.g. [B] inside [A]...[/A] with no [/B]) are marked orphan.

Main pass:
  - Inside a <pre> block, every line is raw content; only </pre> exits. Bracket-tag patterns inside pre no longer disturb depth.
  - Outside pre, [/X] only pops if the stack-top matches by name — mismatched closes render as content, preserving user typos visibly without cascading.
  - Orphan opens render at current depth but don't push, so subsequent closers still find their proper match.

Regex updates:
  - PRE_OPENER_AT_END / PRE_CLOSER_AT_END now allow a trailing # comment.
  - PRE_CLOSER's ^ anchor removed so `content </pre>` still terminates a pre block.
  - \b on the opener prevents <prefix> false matches.
  - Capture groups added so opener/closer names can be matched.

Tests: all 15 existing tests preserved (each re-traced against the new algorithm). 12 new tests cover each of the 6 bugs plus mismatched close, uppercase <PRE>, pre with attributes, orphan </pre>, CRLF/LF output parity, and strong idempotency on a Bug-3 fixture. Total formatEsi suite: 27 tests.